### PR TITLE
Add multi layers support

### DIFF
--- a/src/org/openstreetmap/josm/plugins/todo/TodoDialog.java
+++ b/src/org/openstreetmap/josm/plugins/todo/TodoDialog.java
@@ -9,8 +9,11 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
+import java.util.stream.Collectors;
 
 import javax.swing.AbstractAction;
 import javax.swing.DefaultListSelectionModel;
@@ -26,9 +29,9 @@ import org.openstreetmap.josm.data.SelectionChangedListener;
 import org.openstreetmap.josm.data.osm.OsmPrimitive;
 import org.openstreetmap.josm.data.osm.event.DatasetEventManager.FireMode;
 import org.openstreetmap.josm.data.osm.event.SelectionEventManager;
-import org.openstreetmap.josm.gui.OsmPrimitivRenderer;
 import org.openstreetmap.josm.gui.SideButton;
 import org.openstreetmap.josm.gui.dialogs.ToggleDialog;
+import org.openstreetmap.josm.gui.layer.OsmDataLayer;
 import org.openstreetmap.josm.gui.widgets.ListPopupMenu;
 import org.openstreetmap.josm.gui.widgets.PopupMenuLauncher;
 import org.openstreetmap.josm.tools.ImageProvider;
@@ -40,7 +43,7 @@ public class TodoDialog extends ToggleDialog implements PropertyChangeListener {
 
     private final DefaultListSelectionModel selectionModel = new DefaultListSelectionModel();
     private final TodoListModel model = new TodoListModel(selectionModel);
-    private final JList<OsmPrimitive> lstPrimitives = new JList<>(model);
+    private final JList<TodoListItem> lstPrimitives = new JList<>(model);
     private final AddAction actAdd = new AddAction(model);
     private final PassAction actPass = new PassAction(model);
     private final MarkAction actMark = new MarkAction(model);
@@ -73,7 +76,7 @@ public class TodoDialog extends ToggleDialog implements PropertyChangeListener {
     protected void buildContentPanel() {
         lstPrimitives.setSelectionModel(selectionModel);
         lstPrimitives.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        lstPrimitives.setCellRenderer(new OsmPrimitivRenderer());
+        lstPrimitives.setCellRenderer(new TodoListItemRenderer());
         lstPrimitives.setTransferHandler(null);
 
         // the select action
@@ -100,18 +103,36 @@ public class TodoDialog extends ToggleDialog implements PropertyChangeListener {
         }));
     }
 
-    protected static void selectAndZoom(OsmPrimitive object) {
-        if (object == null || Main.getLayerManager().getEditLayer() == null)
-            return;
-        Main.getLayerManager().getEditLayer().data.setSelected(object);
+    private static void zoom(OsmDataLayer layer) {
+        OsmDataLayer prev = Main.getLayerManager().getEditLayer();
+
+        Main.getLayerManager().setActiveLayer(layer);
         AutoScaleAction.autoScale("selection");
+
+        Main.getLayerManager().setActiveLayer(prev);
     }
 
-    protected static void selectAndZoom(Collection<OsmPrimitive> object) {
-        if (object == null || Main.getLayerManager().getEditLayer() == null)
-            return;
-        Main.getLayerManager().getEditLayer().data.setSelected(object);
-        AutoScaleAction.autoScale("selection");
+    protected static void selectAndZoom(TodoListItem object) {
+        if (object == null) return;
+        object.layer.data.setSelected(object.primitive);
+        zoom(object.layer);
+    }
+
+    protected static void selectAndZoom(Collection<TodoListItem> object) {
+        if (object == null || object.isEmpty()) return;
+        OsmDataLayer layer = null;
+        while (!object.isEmpty()) {
+            layer = ((TodoListItem)object.toArray()[0]).layer;
+            Collection<OsmPrimitive> items = new ArrayList<>();
+            for (Iterator<TodoListItem> it = object.iterator(); it.hasNext();) {
+                TodoListItem item = it.next();
+                if (item.layer != layer) continue;
+                items.add(item.primitive);
+                it.remove();
+            }
+            layer.data.setSelected(items);
+        }
+        zoom(layer);
     }
 
     protected void updateTitle() {
@@ -123,6 +144,14 @@ public class TodoDialog extends ToggleDialog implements PropertyChangeListener {
         SelectionEventManager.getInstance().addSelectionListener(actAdd, FireMode.IN_EDT_CONSOLIDATED);
         SelectionEventManager.getInstance().addSelectionListener(actMarkSelected, FireMode.IN_EDT_CONSOLIDATED);
         actAdd.updateEnabledState();
+    }
+
+    protected Collection<TodoListItem> getItems() {
+        OsmDataLayer layer = Main.getLayerManager().getEditLayer();
+        if (layer == null)
+            return null;
+
+        return layer.data.getSelected().stream().map(primitive -> new TodoListItem(layer, primitive)).collect(Collectors.toList());
     }
 
     private static class SelectAction extends AbstractAction implements ListSelectionListener {
@@ -217,10 +246,7 @@ public class TodoDialog extends ToggleDialog implements PropertyChangeListener {
 
         @Override
         public void actionPerformed(ActionEvent e) {
-            if (Main.getLayerManager().getEditLayer() == null)
-                return;
-            Collection<OsmPrimitive> sel = Main.getLayerManager().getEditLayer().data.getSelected();
-            model.addItems(sel);
+            model.addItems(getItems());
             updateTitle();
         }
 
@@ -251,10 +277,7 @@ public class TodoDialog extends ToggleDialog implements PropertyChangeListener {
 
         @Override
         public void actionPerformed(ActionEvent e) {
-            if (Main.getLayerManager().getEditLayer() == null)
-                return;
-            Collection<OsmPrimitive> sel = Main.getLayerManager().getEditLayer().data.getSelected();
-            model.markItems(sel);
+            model.markItems(getItems());
             updateTitle();
         }
 
@@ -387,7 +410,7 @@ public class TodoDialog extends ToggleDialog implements PropertyChangeListener {
      * A right-click popup context menu for setting options and performing other functions on the todo list items.
      */
     class TodoPopup extends ListPopupMenu {
-        TodoPopup(JList<OsmPrimitive> list) {
+        TodoPopup(JList<TodoListItem> list) {
             super(list);
             add(new SelectAction(model));
             add(new MarkAction(model));

--- a/src/org/openstreetmap/josm/plugins/todo/TodoListItem.java
+++ b/src/org/openstreetmap/josm/plugins/todo/TodoListItem.java
@@ -1,0 +1,33 @@
+// License: GPL. For details, see LICENSE file.
+package org.openstreetmap.josm.plugins.todo;
+
+import org.openstreetmap.josm.data.osm.OsmPrimitive;
+import org.openstreetmap.josm.gui.layer.OsmDataLayer;
+
+public class TodoListItem {
+    OsmDataLayer layer;
+    OsmPrimitive primitive;
+
+    public TodoListItem(OsmDataLayer layer, OsmPrimitive primitive) {
+        this.layer = layer;
+        this.primitive = primitive;
+    }
+
+    @Override
+    public String toString() {
+        return layer.toString() + "/" + primitive.toString();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof TodoListItem))
+            return false;
+        TodoListItem item = (TodoListItem)obj;
+        return layer.equals(item.layer) && primitive.equals(item.primitive);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * layer.hashCode() + primitive.hashCode();
+    }
+}

--- a/src/org/openstreetmap/josm/plugins/todo/TodoListItemRenderer.java
+++ b/src/org/openstreetmap/josm/plugins/todo/TodoListItemRenderer.java
@@ -1,0 +1,45 @@
+// License: GPL. For details, see LICENSE file.
+package org.openstreetmap.josm.plugins.todo;
+
+import java.awt.Component;
+
+import javax.swing.DefaultListCellRenderer;
+import javax.swing.JList;
+import javax.swing.ListCellRenderer;
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
+
+import org.openstreetmap.josm.gui.DefaultNameFormatter;
+import org.openstreetmap.josm.gui.OsmPrimitivRenderer;
+import org.openstreetmap.josm.Main;
+import org.openstreetmap.josm.tools.ImageProvider;
+
+public class TodoListItemRenderer implements ListCellRenderer<TodoListItem> {
+    private final DefaultNameFormatter formatter = DefaultNameFormatter.getInstance();
+    private final DefaultListCellRenderer defaultListCellRenderer = new DefaultListCellRenderer();
+    private final OsmPrimitivRenderer renderer = new OsmPrimitivRenderer();
+    @Override
+    public Component getListCellRendererComponent(JList<? extends TodoListItem> list, TodoListItem value, int index,
+            boolean isSelected, boolean cellHasFocus) {
+        Component def = defaultListCellRenderer.getListCellRendererComponent(list, null, index, isSelected, cellHasFocus);
+        boolean fast = list.getModel().getSize() > 1000;
+
+        if (value != null && def instanceof JLabel) {
+            String displayName = value.primitive.getDisplayName(DefaultNameFormatter.getInstance());
+            String layerName = value.layer.getName();
+            ((JLabel) def).setText(displayName + " [" + layerName + "]");
+            final ImageIcon icon = fast
+                    ? ImageProvider.get(value.primitive.getType())
+                    : ImageProvider.getPadded(value.primitive,
+                        // Height of component no yet known, assume the default 16px.
+                        ImageProvider.ImageSizes.SMALLICON.getImageDimension());
+            if (icon != null) {
+                ((JLabel) def).setIcon(icon);
+            } else {
+                Main.warn("Null icon for "+value.primitive.getDisplayType());
+            }
+            ((JLabel) def).setToolTipText(formatter.buildDefaultToolTip(value.primitive));
+        }
+        return def;
+    }
+}

--- a/src/org/openstreetmap/josm/plugins/todo/TodoListModel.java
+++ b/src/org/openstreetmap/josm/plugins/todo/TodoListModel.java
@@ -10,12 +10,10 @@ import java.util.List;
 import javax.swing.AbstractListModel;
 import javax.swing.DefaultListSelectionModel;
 
-import org.openstreetmap.josm.data.osm.OsmPrimitive;
+public class TodoListModel extends AbstractListModel<TodoListItem> {
 
-public class TodoListModel extends AbstractListModel<OsmPrimitive> {
-
-    private final ArrayList<OsmPrimitive> todoList = new ArrayList<>();
-    private final ArrayList<OsmPrimitive> doneList = new ArrayList<>();
+    private final ArrayList<TodoListItem> todoList = new ArrayList<>();
+    private final ArrayList<TodoListItem> doneList = new ArrayList<>();
     private final DefaultListSelectionModel selectionModel;
 
     public TodoListModel(DefaultListSelectionModel selectionModel) {
@@ -23,7 +21,7 @@ public class TodoListModel extends AbstractListModel<OsmPrimitive> {
     }
 
     @Override
-    public OsmPrimitive getElementAt(int index) {
+    public TodoListItem getElementAt(int index) {
         return todoList.get(index);
     }
 
@@ -36,13 +34,13 @@ public class TodoListModel extends AbstractListModel<OsmPrimitive> {
         return doneList.size();
     }
 
-    public OsmPrimitive getSelected() {
+    public TodoListItem getSelected() {
         if (getSize() == 0 || selectionModel.isSelectionEmpty() || selectionModel.getMinSelectionIndex() >= getSize())
             return null;
         return todoList.get(selectionModel.getMinSelectionIndex());
     }
 
-    public List<OsmPrimitive> getTodoList() {
+    public List<TodoListItem> getTodoList() {
         return todoList;
     }
 
@@ -61,7 +59,7 @@ public class TodoListModel extends AbstractListModel<OsmPrimitive> {
         selectionModel.setSelectionInterval(idx, idx);
     }
 
-    public void addItems(Collection<OsmPrimitive> items) {
+    public void addItems(Collection<TodoListItem> items) {
         if (items == null || items.isEmpty())
             return;
         doneList.removeAll(items);
@@ -72,7 +70,7 @@ public class TodoListModel extends AbstractListModel<OsmPrimitive> {
             selectionModel.setSelectionInterval(0, 0);
         } else {
             todoList.ensureCapacity(size + items.size());
-            for (OsmPrimitive item: items) {
+            for (TodoListItem item: items) {
                 if (!todoList.contains(item))
                     todoList.add(item);
             }
@@ -91,7 +89,7 @@ public class TodoListModel extends AbstractListModel<OsmPrimitive> {
         selectionModel.setSelectionInterval(sel, sel);
     }
 
-    public void setSelected(OsmPrimitive element) {
+    public void setSelected(TodoListItem element) {
         int sel = todoList.indexOf(element);
         if (sel == -1)
             return;
@@ -107,7 +105,7 @@ public class TodoListModel extends AbstractListModel<OsmPrimitive> {
         super.fireIntervalRemoved(this, 0, size-1);
     }
 
-    public void markItems(Collection<OsmPrimitive> items) {
+    public void markItems(Collection<TodoListItem> items) {
         if (items == null || items.isEmpty())
             return;
         int size = getSize();
@@ -116,7 +114,7 @@ public class TodoListModel extends AbstractListModel<OsmPrimitive> {
 
         int sel = selectionModel.getMinSelectionIndex();
 
-        for (OsmPrimitive item: items) {
+        for (TodoListItem item: items) {
             int i;
             if ((i = todoList.indexOf(item)) != -1) {
                 todoList.remove(i);


### PR DESCRIPTION
Currently todo plugin does not support when you switch between layers. Say, for instance, you have data to check in layer *A*, and actual OSM data in layer *B*.
You add all objects from *A* in todo plugin, but you want to check that these data are present (or not) in OSM, so you switch to your work layer *B*.
Whenever you want to mark a todo item *done* or else, you have **to switch to layer A, do the action, and switch back to your work layer**. This PR aims to solve that issue by letting you do the action directly from layer B.

This also add full support for multilayers todo items (if you want some items from layer A and some from layer B) - todolist item will now display the layer in bracket eg `node 1092 [layer A]`:

![image](https://user-images.githubusercontent.com/1451988/29489738-06b84aec-8528-11e7-91a8-f0a724013f8f.png)
