### PR TITLE
Improve performance

### DIFF
--- a/src/org/openstreetmap/josm/plugins/todo/TodoDialog.java
+++ b/src/org/openstreetmap/josm/plugins/todo/TodoDialog.java
@@ -86,7 +86,7 @@ public class TodoDialog extends ToggleDialog implements PropertyChangeListener, 
         model.addListDataListener(new TitleUpdater());
 
         MainApplication.getLayerManager().addLayerChangeListener(this);
-        DatasetEventManager.getInstance().addDatasetListener(model, FireMode.IN_EDT);
+        DatasetEventManager.getInstance().addDatasetListener(model, FireMode.IN_EDT_CONSOLIDATED);
         lstPrimitives.addMouseListener(new DblClickHandler());
         lstPrimitives.addMouseListener(new TodoPopupLauncher());
         toggleAction.addPropertyChangeListener(this);

--- a/src/org/openstreetmap/josm/plugins/todo/TodoListModel.java
+++ b/src/org/openstreetmap/josm/plugins/todo/TodoListModel.java
@@ -5,7 +5,9 @@ import static org.openstreetmap.josm.tools.I18n.tr;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -13,6 +15,7 @@ import javax.swing.AbstractListModel;
 import javax.swing.DefaultListSelectionModel;
 
 import org.openstreetmap.josm.data.osm.OsmPrimitive;
+import org.openstreetmap.josm.data.osm.PrimitiveId;
 import org.openstreetmap.josm.data.osm.event.AbstractDatasetChangedEvent;
 import org.openstreetmap.josm.data.osm.event.DataChangedEvent;
 import org.openstreetmap.josm.data.osm.event.DataSetListener;
@@ -71,10 +74,18 @@ public class TodoListModel extends AbstractListModel<TodoListItem> implements Da
     }
 
     public Collection<TodoListItem> getItemsForPrimitives(Collection<? extends OsmPrimitive> primitives) {
-        return todoList.stream().filter(i -> primitives.stream()
-                                            .anyMatch(p -> i.primitive().equals(p) &&
-                                                           i.layer().getDataSet().equals(p.getDataSet())))
-            .collect(Collectors.toList());
+        final ArrayList<TodoListItem> items = new ArrayList<>(todoList.size());
+        final Map<PrimitiveId, OsmPrimitive> primitiveMap = new HashMap<>(primitives.size());
+        primitives.forEach(primitive -> primitiveMap.put(primitive.getPrimitiveId(), primitive));
+        for (TodoListItem todoListItem : todoList) {
+            final PrimitiveId pid = todoListItem.primitive().getPrimitiveId();
+            if (primitiveMap.containsKey(pid)
+                && todoListItem.layer().getDataSet().equals(primitiveMap.get(pid).getDataSet())) {
+                items.add(todoListItem);
+            }
+        }
+        items.trimToSize();
+        return items;
     }
 
     public List<TodoListItem> getTodoList() {


### PR DESCRIPTION
Todo doesn't need every individual change sent to it; it can take them as a consolidated lump.

Also, avoid streaming through all primitives when looking for items.

Signed-off-by: Taylor Smock <tsmock@meta.com>