### PR TITLE
Fix #23072: Unable to add selection from locked layer

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -7,6 +7,9 @@
     <property name="plugin.description" value="Adds a todo list dialog that makes it easy to go through large lists of objects"/>
     <property name="plugin.icon" value="images/dialogs/todo.png"/>
     <property name="plugin.link" value="https://wiki.openstreetmap.org/wiki/JOSM/Plugins/TODO_list"/>
+    <property name="plugin.minimum.java.version" value="17"/>
+    <property name="java.lang.version" value="17"/>
+    <property name="plugin.canloadatruntime" value="true"/>
 
     <target name="additional-manifest">
         <manifest file="MANIFEST" mode="update">

--- a/src/org/openstreetmap/josm/plugins/todo/TodoListItem.java
+++ b/src/org/openstreetmap/josm/plugins/todo/TodoListItem.java
@@ -3,57 +3,22 @@ package org.openstreetmap.josm.plugins.todo;
 
 import java.util.Objects;
 
-import org.openstreetmap.josm.data.osm.OsmPrimitive;
-import org.openstreetmap.josm.gui.layer.OsmDataLayer;
+import org.openstreetmap.josm.data.osm.IPrimitive;
+import org.openstreetmap.josm.gui.layer.AbstractOsmDataLayer;
 
 /**
  * An item in the todo list
+ * @param layer The originating layer
+ * @param primitive The primitive to do.
  */
-public final class TodoListItem {
-    final OsmDataLayer layer;
-    final OsmPrimitive primitive;
-
-    /**
-     * Create a new item
-     * @param layer The originating layer
-     * @param primitive The primitive to do.
-     */
-    public TodoListItem(OsmDataLayer layer, OsmPrimitive primitive) {
-        this.layer = Objects.requireNonNull(layer, "layer");
-        this.primitive = Objects.requireNonNull(primitive, "primitive");
-    }
-
-    /**
-     * Get the primitive for this object
-     * @return The primitive
-     */
-    public OsmPrimitive primitive() {
-        return this.primitive;
-    }
-
-    /**
-     * Get the layer for this object
-     * @return The originating layer
-     */
-    public OsmDataLayer layer() {
-        return this.layer;
+record TodoListItem(AbstractOsmDataLayer layer, IPrimitive primitive) {
+    TodoListItem {
+        Objects.requireNonNull(layer, "layer");
+        Objects.requireNonNull(primitive, "primitive");
     }
 
     @Override
     public String toString() {
         return layer + "/" + primitive;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (!(obj instanceof TodoListItem))
-            return false;
-        TodoListItem item = (TodoListItem) obj;
-        return layer.equals(item.layer) && primitive.equals(item.primitive);
-    }
-
-    @Override
-    public int hashCode() {
-        return 31 * layer.hashCode() + primitive.hashCode();
     }
 }

--- a/src/org/openstreetmap/josm/plugins/todo/TodoListItemRenderer.java
+++ b/src/org/openstreetmap/josm/plugins/todo/TodoListItemRenderer.java
@@ -10,6 +10,7 @@ import javax.swing.JList;
 import javax.swing.ListCellRenderer;
 
 import org.openstreetmap.josm.data.osm.DefaultNameFormatter;
+import org.openstreetmap.josm.data.osm.OsmPrimitive;
 import org.openstreetmap.josm.tools.ImageProvider;
 import org.openstreetmap.josm.tools.Logging;
 
@@ -30,11 +31,11 @@ public class TodoListItemRenderer implements ListCellRenderer<TodoListItem> {
             String displayName = value.primitive().getDisplayName(DefaultNameFormatter.getInstance());
             String layerName = value.layer().getName();
             ((JLabel) def).setText(displayName + " [" + layerName + "]");
-            final ImageIcon icon = fast
-                    ? ImageProvider.get(value.primitive().getType())
-                    : ImageProvider.getPadded(value.primitive(),
+            final ImageIcon icon = !fast && (value.primitive() instanceof OsmPrimitive osmPrimitive)
+                    ? ImageProvider.getPadded(osmPrimitive,
                         // Height of component no yet known, assume the default 16px.
-                        ImageProvider.ImageSizes.SMALLICON.getImageDimension());
+                        ImageProvider.ImageSizes.SMALLICON.getImageDimension())
+                    : ImageProvider.get(value.primitive().getType());
             if (icon != null) {
                 ((JLabel) def).setIcon(icon);
             } else {

--- a/src/org/openstreetmap/josm/plugins/todo/TodoListModel.java
+++ b/src/org/openstreetmap/josm/plugins/todo/TodoListModel.java
@@ -15,6 +15,7 @@ import java.util.stream.IntStream;
 import javax.swing.AbstractListModel;
 import javax.swing.DefaultListSelectionModel;
 
+import org.openstreetmap.josm.data.osm.IPrimitive;
 import org.openstreetmap.josm.data.osm.OsmPrimitive;
 import org.openstreetmap.josm.data.osm.PrimitiveId;
 import org.openstreetmap.josm.data.osm.event.AbstractDatasetChangedEvent;
@@ -26,7 +27,7 @@ import org.openstreetmap.josm.data.osm.event.PrimitivesRemovedEvent;
 import org.openstreetmap.josm.data.osm.event.RelationMembersChangedEvent;
 import org.openstreetmap.josm.data.osm.event.TagsChangedEvent;
 import org.openstreetmap.josm.data.osm.event.WayNodesChangedEvent;
-import org.openstreetmap.josm.gui.layer.OsmDataLayer;
+import org.openstreetmap.josm.gui.layer.AbstractModifiableLayer;
 import org.openstreetmap.josm.gui.util.TableHelper;
 
 /**
@@ -74,9 +75,9 @@ public class TodoListModel extends AbstractListModel<TodoListItem> implements Da
                 .collect(Collectors.toSet());
     }
 
-    public Collection<TodoListItem> getItemsForPrimitives(Collection<? extends OsmPrimitive> primitives) {
+    public Collection<TodoListItem> getItemsForPrimitives(Collection<? extends IPrimitive> primitives) {
         final ArrayList<TodoListItem> items = new ArrayList<>(todoList.size());
-        final Map<PrimitiveId, OsmPrimitive> primitiveMap = new HashMap<>(primitives.size());
+        final Map<PrimitiveId, IPrimitive> primitiveMap = new HashMap<>(primitives.size());
         primitives.forEach(primitive -> primitiveMap.put(primitive.getPrimitiveId(), primitive));
         for (TodoListItem todoListItem : todoList) {
             final PrimitiveId pid = todoListItem.primitive().getPrimitiveId();
@@ -128,7 +129,7 @@ public class TodoListModel extends AbstractListModel<TodoListItem> implements Da
         }
     }
 
-    public boolean purgeLayerItems(OsmDataLayer layer) {
+    public boolean purgeLayerItems(AbstractModifiableLayer layer) {
         int n = getSize() - 1;
         boolean changed = todoList.removeIf(i -> layer.equals(i.layer()));
         if (changed) {


### PR DESCRIPTION
TODO now allows users to use any modifiable layer (superclass `AbstractModifiableLayer`). As part of this, TODO now allows `IPrimitive` instead of `OsmPrimitive` in `TodoListItem`.